### PR TITLE
Fix Feishu inline image fallback and preserve reply threading across streaming turns

### DIFF
--- a/apps/server/src/__tests__/feishu-streaming.test.ts
+++ b/apps/server/src/__tests__/feishu-streaming.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'bun:test'
+import { createFeishuStreamingStarter } from '../main'
+
+function createStreamingSession(label: string) {
+  return {
+    messageId: label,
+    update: async () => {},
+    complete: async () => {},
+    abort: async () => {},
+  }
+}
+
+describe('createFeishuStreamingStarter', () => {
+  test('uses replyStreaming for the initial message and later turns when reply target exists', async () => {
+    const calls: Array<{ fn: 'reply' | 'send'; value: string }> = []
+    const channel = {
+      replyStreaming: async (messageId: string) => {
+        calls.push({ fn: 'reply', value: messageId })
+        return createStreamingSession(`reply:${messageId}`)
+      },
+      sendStreaming: async (chatId: string) => {
+        calls.push({ fn: 'send', value: chatId })
+        return createStreamingSession(`send:${chatId}`)
+      },
+    }
+
+    const startStreaming = createFeishuStreamingStarter(channel, 'chat-1', 'msg-1')
+
+    const first = await startStreaming()
+    const second = await startStreaming()
+
+    expect(first.messageId).toBe('reply:msg-1')
+    expect(second.messageId).toBe('reply:msg-1')
+    expect(calls).toEqual([
+      { fn: 'reply', value: 'msg-1' },
+      { fn: 'reply', value: 'msg-1' },
+    ])
+  })
+
+  test('uses sendStreaming when no reply target exists', async () => {
+    const calls: Array<{ fn: 'reply' | 'send'; value: string }> = []
+    const channel = {
+      replyStreaming: async (messageId: string) => {
+        calls.push({ fn: 'reply', value: messageId })
+        return createStreamingSession(`reply:${messageId}`)
+      },
+      sendStreaming: async (chatId: string) => {
+        calls.push({ fn: 'send', value: chatId })
+        return createStreamingSession(`send:${chatId}`)
+      },
+    }
+
+    const startStreaming = createFeishuStreamingStarter(channel, 'chat-2')
+
+    const first = await startStreaming()
+    const second = await startStreaming()
+
+    expect(first.messageId).toBe('send:chat-2')
+    expect(second.messageId).toBe('send:chat-2')
+    expect(calls).toEqual([
+      { fn: 'send', value: 'chat-2' },
+      { fn: 'send', value: 'chat-2' },
+    ])
+  })
+})

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -52,6 +52,20 @@ export interface StartOptions {
   onCoreReady?: (zero: ZeroOS) => Promise<void> | void
 }
 
+interface FeishuStreamingStarterChannel {
+  replyStreaming(messageId: string): Promise<FeishuStreamingSession>
+  sendStreaming(chatId: string): Promise<FeishuStreamingSession>
+}
+
+export function createFeishuStreamingStarter(
+  channel: FeishuStreamingStarterChannel,
+  chatId: string,
+  replyToMessageId?: string,
+): () => Promise<FeishuStreamingSession> {
+  return () =>
+    replyToMessageId ? channel.replyStreaming(replyToMessageId) : channel.sendStreaming(chatId)
+}
+
 interface ChannelRuntimeDefinition {
   name: string
   type: 'web' | 'feishu' | 'telegram'
@@ -707,11 +721,10 @@ export async function startZeroOS(options?: StartOptions): Promise<ZeroOS> {
             }
 
             typingReactionId = messageId ? await feishuChannel.react(messageId, 'Typing') : null
+            const startStreaming = createFeishuStreamingStarter(feishuChannel, chatId, messageId)
 
             try {
-              streaming = messageId
-                ? await feishuChannel.replyStreaming(messageId)
-                : await feishuChannel.sendStreaming(chatId)
+              streaming = await startStreaming()
             } catch (err) {
               console.warn(
                 `[ZeRo OS] ${channelName} streaming init failed, falling back to static:`,
@@ -743,8 +756,7 @@ export async function startZeroOS(options?: StartOptions): Promise<ZeroOS> {
                       turnRotateChain = turnRotateChain.then(async () => {
                         try {
                           await streaming!.complete(prevText)
-                          // Create a new streaming card (send to chat, not reply)
-                          streaming = await feishuChannel.sendStreaming(chatId)
+                          streaming = await startStreaming()
                         } catch (err) {
                           console.error(
                             `[ZeRo OS] ${channelName} streaming turn rotate error:`,

--- a/packages/channel/src/__tests__/external-channels.test.ts
+++ b/packages/channel/src/__tests__/external-channels.test.ts
@@ -82,9 +82,21 @@ interface FeishuMessageReplyPayload {
   }
 }
 
+interface FeishuImageCreatePayload {
+  data: {
+    image_type?: string
+    image?: Readable
+  }
+}
+
 interface FeishuTestHarness {
   client: {
     im: {
+      image?: {
+        create?: (
+          payload: FeishuImageCreatePayload,
+        ) => Promise<{ data?: { image_key?: string }; image_key?: string }>
+      }
       messageResource?: {
         get?: (payload: FeishuMessageResourcePayload) => Promise<FeishuBinaryResponseLike>
       }
@@ -697,6 +709,52 @@ describe('FeishuChannel contract', () => {
     expect(calls[2].data.msg_type).toBe('text')
   })
 
+  test('send falls back to standalone image message when inline image cannot be embedded', async () => {
+    const channel = new FeishuChannel({ appId: 'test-id', appSecret: 'test-secret' })
+    const calls: FeishuMessageCreatePayload[] = []
+    const imageUploads: FeishuImageCreatePayload[] = []
+    const originalFetch = globalThis.fetch
+
+    globalThis.fetch = ((async () => new Response('fake-inline-image')) as unknown) as typeof fetch
+    try {
+      getFeishuHarness(channel).client = {
+        im: {
+          image: {
+            create: async (payload: FeishuImageCreatePayload) => {
+              imageUploads.push(payload)
+              if (imageUploads.length === 1) return {}
+              return { data: { image_key: 'img_v3_fallback' } }
+            },
+          },
+          message: {
+            create: async (payload: FeishuMessageCreatePayload) => {
+              calls.push(payload)
+            },
+          },
+        },
+      }
+
+      await channel.send('chat-inline-1', 'Hello\n\n![diagram](https://example.com/demo.png)')
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+
+    expect(imageUploads).toHaveLength(2)
+    expect(calls).toHaveLength(2)
+    expect(calls[0].data.msg_type).toBe('interactive')
+    expect(
+      JSON.parse(calls[0].data.content ?? '').body.elements[0].content.trim(),
+    ).toBe('Hello')
+    expect(calls[1]).toEqual({
+      params: { receive_id_type: 'chat_id' },
+      data: {
+        receive_id: 'chat-inline-1',
+        msg_type: 'image',
+        content: JSON.stringify({ image_key: 'img_v3_fallback' }),
+      },
+    })
+  })
+
   test('reply sends interactive markdown first', async () => {
     const channel = new FeishuChannel({ appId: 'test-id', appSecret: 'test-secret' })
     const calls: FeishuMessageReplyPayload[] = []
@@ -759,6 +817,47 @@ describe('FeishuChannel contract', () => {
         msg_type: 'post',
       },
     })
+  })
+
+  test('reply sends visible notice when inline image embedding and fallback delivery both fail', async () => {
+    const channel = new FeishuChannel({ appId: 'test-id', appSecret: 'test-secret' })
+    const calls: FeishuMessageReplyPayload[] = []
+    const imageUploads: FeishuImageCreatePayload[] = []
+    const originalFetch = globalThis.fetch
+
+    globalThis.fetch = ((async () => new Response('fake-inline-image')) as unknown) as typeof fetch
+    try {
+      getFeishuHarness(channel).client = {
+        im: {
+          image: {
+            create: async (payload: FeishuImageCreatePayload) => {
+              imageUploads.push(payload)
+              return {}
+            },
+          },
+          message: {
+            reply: async (payload: FeishuMessageReplyPayload) => {
+              calls.push(payload)
+            },
+          },
+        },
+      }
+
+      await channel.reply('msg-inline-1', 'Hello\n\n![diagram](https://example.com/demo.png)')
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+
+    expect(imageUploads).toHaveLength(2)
+    expect(calls).toHaveLength(2)
+    expect(calls[0].data.msg_type).toBe('interactive')
+    expect(
+      JSON.parse(calls[0].data.content).body.elements[0].content.trim(),
+    ).toBe('Hello')
+    expect(calls[1].data.msg_type).toBe('interactive')
+    expect(JSON.parse(calls[1].data.content).body.elements[0].content).toBe(
+      '有 1 张图片未能发送，请检查图片引用或稍后重试。',
+    )
   })
 
   test('reply falls back to text when interactive and post replies fail', async () => {

--- a/packages/channel/src/__tests__/richtext-feishu.test.ts
+++ b/packages/channel/src/__tests__/richtext-feishu.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test'
+import { renderMarkdownForFeishu } from '../richtext/feishu'
+
+describe('renderMarkdownForFeishu', () => {
+  test('converts Obsidian wikilink images in normal text', () => {
+    expect(renderMarkdownForFeishu('封面：![[assets/cover.png]]', { preserveExternalImages: true })).toBe(
+      '封面：![cover](assets/cover.png)',
+    )
+  })
+
+  test('does not convert Obsidian wikilink images inside inline code', () => {
+    expect(
+      renderMarkdownForFeishu('请输出这个字面量：`![[assets/cover.png]]`', {
+        preserveExternalImages: true,
+      }),
+    ).toBe('请输出这个字面量：`![[assets/cover.png]]`')
+  })
+
+  test('does not convert Obsidian wikilink images inside fenced code blocks', () => {
+    expect(
+      renderMarkdownForFeishu('```md\n![[assets/cover.png]]\n```', {
+        preserveExternalImages: true,
+      }),
+    ).toBe('```md\n![[assets/cover.png]]\n```')
+  })
+})

--- a/packages/channel/src/feishu/image-resolver.ts
+++ b/packages/channel/src/feishu/image-resolver.ts
@@ -7,6 +7,11 @@ export interface FeishuImageResolverOptions {
   onImageResolved?: () => void
 }
 
+export interface FeishuImageReference {
+  alt: string
+  reference: string
+}
+
 /**
  * Resolves markdown image references to Feishu image keys.
  */
@@ -29,17 +34,8 @@ export class FeishuImageResolver {
   resolveSync(text: string): string {
     if (!this.hasImages(text)) return text
 
-    // Protect code blocks — don't process image refs inside ``` ... ```
-    const codeBlocks: string[] = []
-    let processed = text.replace(/```[\s\S]*?```/g, (match) => {
-      return `__IMG_CODE_BLOCK_${codeBlocks.push(match) - 1}__`
-    })
-
-    // Also protect inline code — don't process image refs inside `...`
-    const inlineCode: string[] = []
-    processed = processed.replace(/`[^`]+`/g, (match) => {
-      return `__IMG_INLINE_CODE_${inlineCode.push(match) - 1}__`
-    })
+    const protectedContent = this.protectCodeContent(text)
+    let processed = protectedContent.processed
 
     processed = processed.replace(IMAGE_RE, (fullMatch, alt: string, value: string) => {
       if (value.startsWith('img_')) return fullMatch
@@ -58,15 +54,7 @@ export class FeishuImageResolver {
       return ''
     })
 
-    // Restore inline code and code blocks
-    inlineCode.forEach((code, i) => {
-      processed = processed.replace(`__IMG_INLINE_CODE_${i}__`, code)
-    })
-    codeBlocks.forEach((block, i) => {
-      processed = processed.replace(`__IMG_CODE_BLOCK_${i}__`, block)
-    })
-
-    return processed
+    return protectedContent.restore(processed)
   }
 
   async resolveAll(text: string, timeoutMs = 30_000): Promise<string> {
@@ -103,9 +91,60 @@ export class FeishuImageResolver {
     return this.pending.size
   }
 
+  collectUnresolved(text: string): FeishuImageReference[] {
+    if (!this.hasImages(text)) return []
+
+    const unresolved: FeishuImageReference[] = []
+    const seen = new Set<string>()
+    const { processed } = this.protectCodeContent(text)
+
+    processed.replace(IMAGE_RE, (fullMatch, alt: string, value: string) => {
+      if (value.startsWith('img_')) return fullMatch
+      if (this.resolved.has(value)) return fullMatch
+      if (seen.has(value)) return fullMatch
+
+      seen.add(value)
+      unresolved.push({ alt, reference: value })
+      return fullMatch
+    })
+
+    return unresolved
+  }
+
   private startUpload(reference: string): void {
     const promise = this.doUpload(reference)
     this.pending.set(reference, promise)
+  }
+
+  private protectCodeContent(text: string): {
+    processed: string
+    restore: (input: string) => string
+  } {
+    const codeBlocks: string[] = []
+    let processed = text.replace(/```[\s\S]*?```/g, (match) => {
+      return `__IMG_CODE_BLOCK_${codeBlocks.push(match) - 1}__`
+    })
+
+    const inlineCode: string[] = []
+    processed = processed.replace(/`[^`]+`/g, (match) => {
+      return `__IMG_INLINE_CODE_${inlineCode.push(match) - 1}__`
+    })
+
+    return {
+      processed,
+      restore: (input: string) => {
+        let restored = input
+
+        inlineCode.forEach((code, i) => {
+          restored = restored.replace(`__IMG_INLINE_CODE_${i}__`, code)
+        })
+        codeBlocks.forEach((block, i) => {
+          restored = restored.replace(`__IMG_CODE_BLOCK_${i}__`, block)
+        })
+
+        return restored
+      },
+    }
   }
 
   private async doUpload(reference: string): Promise<string | null> {

--- a/packages/channel/src/feishu/image-resolver.ts
+++ b/packages/channel/src/feishu/image-resolver.ts
@@ -1,4 +1,5 @@
 import type * as lark from '@larksuiteoapi/node-sdk'
+import { protectMarkdownCodeContent } from '../richtext/code-protection'
 
 const IMAGE_RE = /!\[([^\]]*)\]\(([^)\s]+)\)/g
 
@@ -120,31 +121,7 @@ export class FeishuImageResolver {
     processed: string
     restore: (input: string) => string
   } {
-    const codeBlocks: string[] = []
-    let processed = text.replace(/```[\s\S]*?```/g, (match) => {
-      return `__IMG_CODE_BLOCK_${codeBlocks.push(match) - 1}__`
-    })
-
-    const inlineCode: string[] = []
-    processed = processed.replace(/`[^`]+`/g, (match) => {
-      return `__IMG_INLINE_CODE_${inlineCode.push(match) - 1}__`
-    })
-
-    return {
-      processed,
-      restore: (input: string) => {
-        let restored = input
-
-        inlineCode.forEach((code, i) => {
-          restored = restored.replace(`__IMG_INLINE_CODE_${i}__`, code)
-        })
-        codeBlocks.forEach((block, i) => {
-          restored = restored.replace(`__IMG_CODE_BLOCK_${i}__`, block)
-        })
-
-        return restored
-      },
-    }
+    return protectMarkdownCodeContent(text, 'IMG')
   }
 
   private async doUpload(reference: string): Promise<string | null> {

--- a/packages/channel/src/feishu/index.ts
+++ b/packages/channel/src/feishu/index.ts
@@ -2,6 +2,7 @@ import type { Readable } from 'node:stream'
 import * as lark from '@larksuiteoapi/node-sdk'
 import type { Channel, ImageAttachment, IncomingMessage, MessageHandler } from '../base'
 import { renderMarkdownForFeishu } from '../richtext/feishu'
+import type { FeishuImageReference } from './image-resolver'
 import { FeishuImageResolver } from './image-resolver'
 
 export interface FeishuChannelConfig {
@@ -54,6 +55,11 @@ interface FeishuPostElement {
   user_id?: string
   file_name?: string
   emoji_type?: string
+}
+
+interface FeishuImageTarget {
+  chatId?: string
+  replyToMessageId?: string
 }
 
 /**
@@ -198,11 +204,14 @@ export class FeishuChannel implements Channel {
     }
 
     let rendered = renderMarkdownForFeishu(content, { preserveExternalImages: true })
+    let unresolvedImages: FeishuImageReference[] = []
 
     // Resolve image references (URL / local path → img_key)
     if (this.client && new FeishuImageResolver({ client: this.client }).hasImages(rendered)) {
       const resolver = new FeishuImageResolver({ client: this.client })
-      rendered = await resolver.resolveAll(rendered, 30_000)
+      const originalRendered = rendered
+      rendered = await resolver.resolveAll(originalRendered, 30_000)
+      unresolvedImages = resolver.collectUnresolved(originalRendered)
     }
 
     const isNotification = content.startsWith('[notification]')
@@ -210,39 +219,49 @@ export class FeishuChannel implements Channel {
     const options = isNotification
       ? { title: 'ZeRo OS Notification', template: 'orange' }
       : undefined
-    const chunks = this.chunkRichContent(cleanContent, options)
+    if (cleanContent.trim()) {
+      const chunks = this.chunkRichContent(cleanContent, options)
 
-    for (let i = 0; i < chunks.length; i++) {
-      const chunkOptions = i === 0 ? options : undefined
-      await this.sendCreateWithFallback(sessionId, chunks[i], chunkOptions)
+      for (let i = 0; i < chunks.length; i++) {
+        const chunkOptions = i === 0 ? options : undefined
+        await this.sendCreateWithFallback(sessionId, chunks[i], chunkOptions)
+      }
     }
+
+    await this.deliverUnresolvedInlineImages(unresolvedImages, { chatId: sessionId }, 'send')
   }
 
   async sendStreaming(sessionId: string): Promise<FeishuStreamingSession> {
-    return this.createStreamingSession(async (cardId) => {
-      const response = await this.client!.im.message.create({
-        data: {
-          receive_id: sessionId,
-          msg_type: 'interactive',
-          content: this.buildCardReferenceContent(cardId),
-        },
-        params: { receive_id_type: 'chat_id' },
-      })
-      return response.data?.message_id ?? null
-    })
+    return this.createStreamingSession(
+      async (cardId) => {
+        const response = await this.client!.im.message.create({
+          data: {
+            receive_id: sessionId,
+            msg_type: 'interactive',
+            content: this.buildCardReferenceContent(cardId),
+          },
+          params: { receive_id_type: 'chat_id' },
+        })
+        return response.data?.message_id ?? null
+      },
+      { chatId: sessionId },
+    )
   }
 
   async replyStreaming(messageId: string): Promise<FeishuStreamingSession> {
-    return this.createStreamingSession(async (cardId) => {
-      const response = await this.client!.im.message.reply({
-        path: { message_id: messageId },
-        data: {
-          msg_type: 'interactive',
-          content: this.buildCardReferenceContent(cardId),
-        },
-      })
-      return response.data?.message_id ?? null
-    })
+    return this.createStreamingSession(
+      async (cardId) => {
+        const response = await this.client!.im.message.reply({
+          path: { message_id: messageId },
+          data: {
+            msg_type: 'interactive',
+            content: this.buildCardReferenceContent(cardId),
+          },
+        })
+        return response.data?.message_id ?? null
+      },
+      { replyToMessageId: messageId },
+    )
   }
 
   isConnected(): boolean {
@@ -451,17 +470,24 @@ export class FeishuChannel implements Channel {
     }
 
     let rendered = renderMarkdownForFeishu(content, { preserveExternalImages: true })
+    let unresolvedImages: FeishuImageReference[] = []
 
     // Resolve image references (URL / local path → img_key)
     if (this.client && new FeishuImageResolver({ client: this.client }).hasImages(rendered)) {
       const resolver = new FeishuImageResolver({ client: this.client })
-      rendered = await resolver.resolveAll(rendered, 30_000)
+      const originalRendered = rendered
+      rendered = await resolver.resolveAll(originalRendered, 30_000)
+      unresolvedImages = resolver.collectUnresolved(originalRendered)
     }
 
-    const chunks = this.chunkRichContent(rendered)
-    for (const chunk of chunks) {
-      await this.sendReplyWithFallback(messageId, chunk)
+    if (rendered.trim()) {
+      const chunks = this.chunkRichContent(rendered)
+      for (const chunk of chunks) {
+        await this.sendReplyWithFallback(messageId, chunk)
+      }
     }
+
+    await this.deliverUnresolvedInlineImages(unresolvedImages, { replyToMessageId: messageId }, 'reply')
   }
 
   /**
@@ -471,44 +497,7 @@ export class FeishuChannel implements Channel {
    * @param replyToMessageId - Optional message ID to reply to
    */
   async sendImage(chatId: string, image: Buffer | string, replyToMessageId?: string): Promise<void> {
-    if (!this.client) return
-
-    try {
-      const imageBuffer =
-        typeof image === 'string' ? (await import('node:fs')).readFileSync(image) : image
-
-      const { Readable } = await import('node:stream')
-      const uploadResp = await this.client.im.image.create({
-        data: {
-          image_type: 'message',
-          image: Readable.from(imageBuffer) as any,
-        },
-      })
-
-      const imageKey = (uploadResp as any)?.data?.image_key ?? (uploadResp as any)?.image_key
-      if (!imageKey) {
-        console.warn('[FeishuChannel] Image upload failed: no image_key in response')
-        return
-      }
-
-      const content = JSON.stringify({ image_key: imageKey })
-
-      if (replyToMessageId) {
-        await this.client.im.message.reply({
-          path: { message_id: replyToMessageId },
-          data: { content, msg_type: 'image' },
-        })
-      } else {
-        await this.client.im.message.create({
-          params: { receive_id_type: 'chat_id' as any },
-          data: { receive_id: chatId, msg_type: 'image', content },
-        })
-      }
-
-      console.log('[FeishuChannel] Image sent successfully')
-    } catch (error) {
-      console.error('[FeishuChannel] Failed to send image:', this.describeError(error))
-    }
+    await this.sendImageMessage(image, { chatId, replyToMessageId })
   }
 
   /**
@@ -836,8 +825,124 @@ export class FeishuChannel implements Channel {
     return typeMap[ext] ?? 'stream'
   }
 
+  private async sendImageMessage(
+    image: Buffer | string,
+    target: FeishuImageTarget,
+  ): Promise<boolean> {
+    if (!this.client) return false
+
+    try {
+      const imageBuffer =
+        typeof image === 'string' ? (await import('node:fs')).readFileSync(image) : image
+
+      const { Readable } = await import('node:stream')
+      const uploadResp = await this.client.im.image.create({
+        data: {
+          image_type: 'message',
+          image: Readable.from(imageBuffer) as any,
+        },
+      })
+
+      const imageKey = (uploadResp as any)?.data?.image_key ?? (uploadResp as any)?.image_key
+      if (!imageKey) {
+        console.warn('[FeishuChannel] Image upload failed: no image_key in response')
+        return false
+      }
+
+      const content = JSON.stringify({ image_key: imageKey })
+
+      if (target.replyToMessageId) {
+        await this.client.im.message.reply({
+          path: { message_id: target.replyToMessageId },
+          data: { content, msg_type: 'image' },
+        })
+      } else if (target.chatId) {
+        await this.client.im.message.create({
+          params: { receive_id_type: 'chat_id' as any },
+          data: { receive_id: target.chatId, msg_type: 'image', content },
+        })
+      } else {
+        return false
+      }
+
+      console.log('[FeishuChannel] Image sent successfully')
+      return true
+    } catch (error) {
+      console.error('[FeishuChannel] Failed to send image:', this.describeError(error))
+      return false
+    }
+  }
+
+  private async sendImageReference(
+    reference: string,
+    target: FeishuImageTarget,
+  ): Promise<boolean> {
+    if (reference.startsWith('http://') || reference.startsWith('https://')) {
+      try {
+        const resp = await fetch(reference, { signal: AbortSignal.timeout(15_000) })
+        if (!resp.ok) {
+          throw new Error(`HTTP ${resp.status}`)
+        }
+        return await this.sendImageMessage(Buffer.from(await resp.arrayBuffer()), target)
+      } catch (error) {
+        console.warn(
+          `[FeishuChannel] Failed to fetch fallback image ${reference}:`,
+          this.describeError(error),
+        )
+        return false
+      }
+    }
+
+    if (reference.startsWith('data:')) {
+      const match = reference.match(/^data:[^;,]+;base64,([\s\S]+)$/)
+      if (!match) {
+        console.warn('[FeishuChannel] Unsupported inline image data URI')
+        return false
+      }
+      return this.sendImageMessage(Buffer.from(match[1], 'base64'), target)
+    }
+
+    return this.sendImageMessage(reference, target)
+  }
+
+  private async deliverUnresolvedInlineImages(
+    images: FeishuImageReference[],
+    target: FeishuImageTarget,
+    source: 'send' | 'reply' | 'streaming',
+  ): Promise<void> {
+    if (images.length === 0) return
+
+    let failures = 0
+    for (const image of images) {
+      const delivered = await this.sendImageReference(image.reference, target)
+      if (!delivered) {
+        failures += 1
+      }
+    }
+
+    if (failures === 0) return
+
+    const notice = this.buildInlineImageFailureNotice(failures)
+    if (target.replyToMessageId) {
+      await this.sendReplyWithFallback(target.replyToMessageId, notice)
+    } else if (target.chatId) {
+      await this.sendCreateWithFallback(target.chatId, notice)
+    }
+
+    console.warn(
+      `[FeishuChannel] ${source} inline image fallback incomplete: ${failures} image(s) failed`,
+    )
+  }
+
+  private buildInlineImageFailureNotice(failureCount: number): string {
+    return failureCount === 1
+      ? '有 1 张图片未能发送，请检查图片引用或稍后重试。'
+      : `有 ${failureCount} 张图片未能发送，请检查图片引用或稍后重试。`
+  }
+
   private async createStreamingSession(
     attachMessage: (cardId: string) => Promise<string | null>,
+    fallbackTarget: FeishuImageTarget,
   ): Promise<FeishuStreamingSession> {
     if (!this.client) {
       throw new Error('Feishu client not initialized')
@@ -993,11 +1098,14 @@ export class FeishuChannel implements Channel {
       complete: async (finalText: string) => {
         const rendered = renderStreamingMarkdown(finalText)
         latestRenderedText = rendered
+        let unresolvedImages: FeishuImageReference[] = []
         const finalRendered =
           imageResolver.hasImages(rendered) || imageResolver.pendingCount > 0
             ? await imageResolver.resolveAll(rendered, 30_000)
             : imageResolver.resolveSync(rendered)
+        unresolvedImages = imageResolver.collectUnresolved(rendered)
         await finalizeCard(finalRendered, 'streaming completion failed')
+        await this.deliverUnresolvedInlineImages(unresolvedImages, fallbackTarget, 'streaming')
       },
       abort: async (errorMessage?: string) => {
         let rendered = renderMarkdownForFeishu(

--- a/packages/channel/src/richtext/code-protection.ts
+++ b/packages/channel/src/richtext/code-protection.ts
@@ -1,0 +1,35 @@
+export interface ProtectedMarkdownCodeContent {
+  processed: string
+  restore(input: string): string
+}
+
+export function protectMarkdownCodeContent(
+  text: string,
+  placeholderPrefix = 'CODE',
+): ProtectedMarkdownCodeContent {
+  const codeBlocks: string[] = []
+  let processed = text.replace(/```[\s\S]*?```/g, (match) => {
+    return `__${placeholderPrefix}_BLOCK_${codeBlocks.push(match) - 1}__`
+  })
+
+  const inlineCode: string[] = []
+  processed = processed.replace(/`[^`]+`/g, (match) => {
+    return `__${placeholderPrefix}_INLINE_${inlineCode.push(match) - 1}__`
+  })
+
+  return {
+    processed,
+    restore: (input: string) => {
+      let restored = input
+
+      inlineCode.forEach((code, i) => {
+        restored = restored.replace(`__${placeholderPrefix}_INLINE_${i}__`, code)
+      })
+      codeBlocks.forEach((block, i) => {
+        restored = restored.replace(`__${placeholderPrefix}_BLOCK_${i}__`, block)
+      })
+
+      return restored
+    },
+  }
+}

--- a/packages/channel/src/richtext/feishu.ts
+++ b/packages/channel/src/richtext/feishu.ts
@@ -1,3 +1,4 @@
+import { protectMarkdownCodeContent } from './code-protection'
 import { normalizeMarkdownForChannels } from './normalize'
 
 interface RenderMarkdownForFeishuOptions {
@@ -26,10 +27,8 @@ function optimizeMarkdownForFeishu(
   text: string,
   options?: RenderMarkdownForFeishuOptions,
 ): string {
-  const codeBlocks: string[] = []
-  let result = text.replace(/```[\s\S]*?```/g, (match) => {
-    return `__CODE_BLOCK_${codeBlocks.push(match) - 1}__`
-  })
+  const protectedContent = protectMarkdownCodeContent(text, 'FEISHU_MD')
+  let result = protectedContent.processed
 
   // Convert Obsidian wikilink images ![[path]] to standard markdown ![alt](path)
   // This must happen before the image reference processing below
@@ -58,10 +57,7 @@ function optimizeMarkdownForFeishu(
     '<at user_id="$1">',
   )
 
-  codeBlocks.forEach((block, i) => {
-    result = result.replace(`__CODE_BLOCK_${i}__`, block)
-  })
-
+  result = protectedContent.restore(result)
   result = result.replace(/\n{3,}/g, '\n\n')
 
   return result


### PR DESCRIPTION
## Summary
- prevent Feishu markdown images from being silently dropped when inline embedding fails
- fall back to standalone image messages and send a visible notice if fallback delivery also fails
- preserve `replyStreaming(messageId)` behavior across turn rotation instead of switching later cards to chat-level sends
- share code/inlined code protection for Feishu markdown handling so Obsidian `![[...]]` refs stay literal inside inline and fenced code blocks
- add focused Feishu tests for inline image fallback, streaming starter behavior, and richtext code protection

## Testing
- `bun test packages/channel/src/__tests__/external-channels.test.ts`
- `bun test apps/server/src/__tests__/feishu-streaming.test.ts`
- `bun test packages/channel/src/__tests__/richtext-feishu.test.ts`
- `bun run check`